### PR TITLE
refactor: R{FST}(buffer, offset) record constructor style

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -29,23 +29,23 @@ function CDFDataset(filename)
         buffer = Mmap.mmap(io)
         magic_bytes = read_be(buffer, 1, UInt32)
         @assert validate_cdf_magic(magic_bytes)
-        return is_cdf_v3(magic_bytes) ? _load_dataset(fname, buffer, Int64) :
-            _load_dataset(fname, buffer, Int32)
+        return is_cdf_v3(magic_bytes) ? CDFDataset{Int64}(fname, buffer) :
+            CDFDataset{Int32}(fname, buffer)
     finally
         close(io)
     end
 end
 
-function _load_dataset(fname, buffer, ::Type{FieldSizeType}) where {FieldSizeType}
+function CDFDataset{FST}(fname, buffer) where {FST}
     compression = NoCompression
     if is_compressed(read_be(buffer, 5, UInt32))
         mmapped = buffer
-        buffer, compression = decompress_bytes(buffer, FieldSizeType)
+        buffer, compression = decompress_bytes(buffer, FST)
         finalize(mmapped)
     end
-    cdr = CDR(buffer, 8, FieldSizeType)
-    gdr = GDR(buffer, Int(cdr.gdr_offset), FieldSizeType)
-    return CDFDataset{FieldSizeType}(fname, cdr, gdr, buffer, compression)
+    cdr = CDR{FST}(buffer, 8)
+    gdr = GDR{FST}(buffer, Int(cdr.gdr_offset))
+    return CDFDataset{FST}(fname, cdr, gdr, buffer, compression)
 end
 
 Base.close(cdf::CDFDataset) = (finalize(parent(cdf)); nothing)
@@ -62,20 +62,19 @@ majority(cdf::CDFDataset) = majority(cdf.cdr)
     name in fieldnames(CDFDataset) && return getfield(cdf, name)
     name === :version && return version(getfield(cdf, :cdr))
     name === :majority && return majority(cdf)
-    name === :adr && return ADR(parent(cdf), GDR(cdf).ADRhead, recordsize_type(cdf))
+    name === :adr && return ADR{recordsize_type(cdf)}(parent(cdf), GDR(cdf).ADRhead)
     name === :attrib && return attrib(cdf)
     name === :vattrib && return attrib(cdf; predicate = !is_global)
     throw(ArgumentError("Unknown property $name"))
 end
 
 # Load the (z or r) VDR at a known offset
-function _vdr_at(cdf::CDFDataset, offset::Int)
+function _vdr_at(cdf::CDFDataset{FST}, offset::Int) where {FST}
     buffer = parent(cdf)
-    RecordSizeType = recordsize_type(cdf)
-    record_type = read_be(buffer, offset + 1 + sizeof(RecordSizeType), Int32)
+    record_type = read_be(buffer, offset + 1 + sizeof(FST), Int32)
     @assert record_type in (8, 3)
-    return record_type == 8 ? VDR(buffer, offset, RecordSizeType) :
-        rVDR(buffer, offset, GDR(cdf), RecordSizeType)
+    return record_type == 8 ? VDR{FST}(buffer, offset) :
+        rVDR{FST}(buffer, offset, GDR(cdf))
 end
 
 function find_vdr(cdf::CDFDataset, var_name::String)

--- a/src/loading/attribute.jl
+++ b/src/loading/attribute.jl
@@ -21,7 +21,7 @@ function attrib(cdf::CDFDataset; predicate = is_global)
     needs_byte_swap = is_big_endian_encoding(cdf)
     result = Dict{String, Vector}()
     for offset in OffsetsIterator(cdf)
-        adr = ADR(buffer, offset, RecordSizeType)
+        adr = ADR{RecordSizeType}(buffer, offset)
         predicate(adr) || continue
         result[String(adr.Name)] = load_attribute_entries(buffer, adr, RecordSizeType, needs_byte_swap)
     end
@@ -33,15 +33,14 @@ end
 
 Retrieve all entries for a named attribute from the CDF file.
 """
-function attrib(cdf::CDFDataset, name::String)
-    RecordSizeType = recordsize_type(cdf)
+function attrib(cdf::CDFDataset{FST}, name::String) where {FST}
     buffer = cdf.buffer
     needs_byte_swap = is_big_endian_encoding(cdf)
     offsets = OffsetsIterator(cdf)
     name_bytes = codeunits(name)
     for offset in offsets
-        adr = ADR(buffer, offset, RecordSizeType)
-        name_bytes == adr.Name && return load_attribute_entries(buffer, adr, RecordSizeType, needs_byte_swap)
+        adr = ADR{FST}(buffer, offset)
+        name_bytes == adr.Name && return load_attribute_entries(buffer, adr, FST, needs_byte_swap)
     end
     error("Attribute '$name' not found in CDF file")
 end
@@ -63,7 +62,7 @@ function Base.iterate(la::LazyVAttrib, offset::Int = Int(la.cdf.gdr.ADRhead))
             offset = Int(read_be(buffer, offset + 1 + sizeof(RecordSizeType) + 4, RecordSizeType))
             continue
         end
-        adr = ADR(buffer, offset, RecordSizeType)
+        adr = ADR{RecordSizeType}(buffer, offset)
         next_offset = Int(adr.ADRnext)
         for head in (adr.AgrEDRhead, adr.AzEDRhead)
             head == 0 && continue
@@ -95,7 +94,7 @@ function Base.get(la::LazyVAttrib, name::AbstractString, default = nothing)
     needs_byte_swap = is_big_endian_encoding(cdf)
     for offset in OffsetsIterator(cdf)
         is_global(buffer, offset, RecordSizeType) && continue
-        adr = ADR(buffer, offset, RecordSizeType)
+        adr = ADR{RecordSizeType}(buffer, offset)
         adr.Name != name_bytes && continue
         for head in (adr.AgrEDRhead, adr.AzEDRhead)
             head == 0 && continue
@@ -142,12 +141,11 @@ end
 
 Return a list of attribute names in the CDF file.
 """
-function attribnames(cdf::CDFDataset; predicate = is_global)
+function attribnames(cdf::CDFDataset{FST}; predicate = is_global) where {FST}
     names = String[]
     buffer = cdf.buffer
-    RecordSizeType = recordsize_type(cdf)
     for offset in OffsetsIterator(cdf)
-        adr = ADR(buffer, offset, RecordSizeType)
+        adr = ADR{FST}(buffer, offset)
         predicate(adr) && push!(names, String(adr.Name))
     end
     return names

--- a/src/loading/variable.jl
+++ b/src/loading/variable.jl
@@ -204,7 +204,7 @@ end
 function collect_vxr_entries!(entries::Vector{VVREntry}, src, offset, ::Type{FieldSizeT}) where {FieldSizeT}
     vvr_type = nothing
     while offset != 0
-        vxr = VXR(src, offset, FieldSizeT)
+        vxr = VXR{FieldSizeT}(src, offset)
         for (first, last, leaf_offset) in vxr
             record_type = get_record_type(src, leaf_offset, FieldSizeT)
             @assert record_type in (VVR_, CVVR_, VXR_)

--- a/src/records/adr.jl
+++ b/src/records/adr.jl
@@ -24,15 +24,10 @@ is_global(buffer, offset, ::Type{Int32}) = read_be(buffer, offset + 17, Int32) =
 is_global(buffer, offset, ::Type{Int64}) = read_be(buffer, offset + 29, Int32) == 1
 
 
-"""
-    ADR(buf, offset, RecordSizeType)
-
-Load an Attribute Descriptor Record from the buffer at the specified position.
-"""
-@inline function ADR(buffer::Vector{UInt8}, offset, ::Type{RecordSizeType}) where {RecordSizeType}
-    pos = check_record_type(4, buffer, offset, RecordSizeType)
+@inline function ADR{FST}(buffer::Vector{UInt8}, offset) where {FST}
+    pos = check_record_type(4, buffer, offset, FST)
     # Read ADR fields
-    fields, pos = read_be_fields(buffer, pos, ADR{RecordSizeType, String}, Val(1:11))
+    fields, pos = read_be_fields(buffer, pos, ADR{FST, String}, Val(1:11))
     name = readname(buffer, pos)
     return ADR(fields..., name)
 end

--- a/src/records/cdr.jl
+++ b/src/records/cdr.jl
@@ -21,14 +21,8 @@ version(cdr::CDR; verbose = true) = verbose ? (cdr.version, cdr.release, cdr.inc
 majority(cdr::CDR) = (cdr.flags & 0x01) != 0 ? Row : Column  # Row=0, Column=1
 is_cdf_v3(cdr::CDR) = cdr.version == 3
 
-"""
-    CDR(buffer, pos, FieldSizeT)
-
-Load a CDF Descriptor Record from the IO stream at the specified offset.
-This follows the CDF specification for CDR record structure.
-"""
-@inline function CDR(buffer::Vector{UInt8}, offset, ::Type{FieldSizeT}) where {FieldSizeT}
-    pos = check_record_type(1, buffer, offset, FieldSizeT)
-    fields, pos = read_be_fields(buffer, pos, CDR{FieldSizeT}, Val(1:9))
+@inline function CDR{FST}(buffer::Vector{UInt8}, offset) where {FST}
+    pos = check_record_type(1, buffer, offset, FST)
+    fields, pos = read_be_fields(buffer, pos, CDR{FST}, Val(1:9))
     return CDR(fields...)
 end

--- a/src/records/gdr.jl
+++ b/src/records/gdr.jl
@@ -22,14 +22,9 @@ struct GDR{FS}
 end
 
 
-"""
-    GDR(buffer::Vector{UInt8}, pos, FieldSizeT)
-
-Load a Global Descriptor Record from the buffer at the specified offset.
-"""
-@inline function GDR(buffer::Vector{UInt8}, offset, FieldSizeT)
-    pos = check_record_type(2, buffer, offset, FieldSizeT)
-    fields, pos = read_be_fields(buffer, pos, GDR{FieldSizeT}, Val(1:9))
+@inline function GDR{FST}(buffer::Vector{UInt8}, offset) where {FST}
+    pos = check_record_type(2, buffer, offset, FST)
+    fields, pos = read_be_fields(buffer, pos, GDR{FST}, Val(1:9))
     return GDR(fields..., pos)
 end
 

--- a/src/records/vdr.jl
+++ b/src/records/vdr.jl
@@ -51,11 +51,11 @@ struct VDR{FST} <: AbstractVDR{FST}
 end
 
 """
-    VDR(io::IO, FieldSizeT)
+    VDR{FieldSizeT}(buffer, offset)
 
-Load a Variable Descriptor Record from the IO stream at the specified offset.
+Load a z-Variable Descriptor Record from the buffer at the specified offset.
 """
-@inline function VDR(buffer::Vector{UInt8}, offset, ::Type{FieldSizeT}) where {FieldSizeT}
+@inline function VDR{FieldSizeT}(buffer::Vector{UInt8}, offset) where {FieldSizeT}
     pos = check_record_type(8, buffer, offset, FieldSizeT)
     fields, pos = read_be_fields(buffer, pos, VDR{FieldSizeT}, Val(1:13))
     # name = readname(buffer, pos)
@@ -66,11 +66,11 @@ Load a Variable Descriptor Record from the IO stream at the specified offset.
 end
 
 """
-    rVDR(io::IO, FieldSizeT)
+    rVDR{FieldSizeT}(buffer, offset, gdr)
 
-Load a Variable Descriptor Record from the IO stream at the specified offset.
+Load an r-Variable Descriptor Record from the buffer at the specified offset.
 """
-@inline function rVDR(buffer::Vector{UInt8}, offset, gdr, ::Type{FieldSizeT}) where {FieldSizeT}
+@inline function rVDR{FieldSizeT}(buffer::Vector{UInt8}, offset, gdr) where {FieldSizeT}
     pos = check_record_type(3, buffer, offset, FieldSizeT)
     fields, pos = read_be_fields(buffer, pos, rVDR{FieldSizeT}, Val(1:13))
     pos = FieldSizeT == Int64 ? offset + 340 + 1 : offset + 128 + 1

--- a/src/records/vvr.jl
+++ b/src/records/vvr.jl
@@ -1,6 +1,3 @@
-# Variable data loading functionality
-# Handles VVR (Variable Value Record) parsing and data extraction
-
 """
 Variable Value Record (VVR) - contains actual variable data
 """

--- a/src/records/vxr.jl
+++ b/src/records/vxr.jl
@@ -12,27 +12,21 @@ struct VXR{FieldSizeT}
     # offset::Tuple{Vararg{Int64}}  # Offsets to VVR/CVVR records
 end
 
-
-"""
-    VXR(source, offset, RecordSizeType)
-
-Load a Variable Index Record from the source at the specified offset.
-"""
-function VXR(source::Vector{UInt8}, offset, ::Type{FieldSizeT}) where {FieldSizeT}
-    pos = check_record_type(6, source, offset, FieldSizeT)
-    vxr_next, pos = read_be_i(source, pos, FieldSizeT)
+function VXR{FST}(source::Vector{UInt8}, offset) where {FST}
+    pos = check_record_type(6, source, offset, FST)
+    vxr_next, pos = read_be_i(source, pos, FST)
     n_entries, pos = read_be_i(source, pos, Int32)
     n_used_entries, pos = read_be_i(source, pos, Int32)
     p = convert(Ptr{Int32}, pointer(source, pos))
     return VXR(vxr_next, n_entries, n_used_entries, p)
 end
 
-function Base.iterate(vxr::VXR{FieldSizeT}, state = 1) where {FieldSizeT}
+function Base.iterate(vxr::VXR{FST}, state = 1) where {FST}
     state > vxr.n_used_entries && return nothing
     pointer = vxr.pointer
     first = read_be(pointer, state)
     last = read_be(pointer, state + vxr.n_entries)
-    offset_pointer = convert(Ptr{FieldSizeT}, pointer + (2 * vxr.n_entries) * sizeof(Int32))
+    offset_pointer = convert(Ptr{FST}, pointer + (2 * vxr.n_entries) * sizeof(Int32))
     offset = read_be(offset_pointer, state)
     return ((first, last, Int(offset)), state + 1)
 end


### PR DESCRIPTION
Move the field-size type from a trailing positional argument into the
type parameter for the records that already carry it (CDR, GDR, VDR,
rVDR, VXR, ADR). CPR/CCR/CVVR keep the positional form: their structs
are not parameterized by FST — there it is a parsing parameter, not
type identity. No behavior change; trim-equivalent (where-param either
way).
